### PR TITLE
Update character limit for message text field. Resolved #2

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a small change to the `Message` class in the `RazorPagesTestSample` application. The change increases the maximum allowed length for the `Text` property from 200 to 250 characters.

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450L12-R12): Increased the `StringLength` attribute for the `Text` property from 200 to 250 characters.